### PR TITLE
hack to fix train-v11 in dvc.lock

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -55,7 +55,7 @@ stages:
       size: 3447187507
       nfiles: 1314
     outs:
-    - path: data/training/teo/v1/faster-rcnn/
+    - path: data/training/teo/v11/faster-rcnn/
       hash: md5
       md5: 321c094af1b41f361e24a3961ede1959.dir
       size: 165705359


### PR DESCRIPTION
Pequeño hack para arreglar el problemita del model v11...
Solo cambié el directorio de destino pero el hash es el mismo que de `v1` entonces se estaría trayendo ese mismo modelo.

Ahorita, puedo poner otro modelo regenerado con el verdadero config v11 acá... Permanezcan en sintonía!
